### PR TITLE
Deadlock fix

### DIFF
--- a/AVI_FAS_FMC/CM4/Core/Src/main.c
+++ b/AVI_FAS_FMC/CM4/Core/Src/main.c
@@ -368,15 +368,16 @@ void CM4StatusLEDTask(void *argument)
     // Format a message
     format_str(to_cm7_buf, 48, "To CM7: %d\0", num++);
     
-    // As CM4, Send message to CM7
-    // while(!core_comms_channel_acknowledged(comm_CM4_to_CM7_messages_ptr));
-    status = core_comms_channel_send(comm_CM4_to_CM7_messages_ptr, (uint8_t *) to_cm7_buf, 48);
-
     // As CM4, Receive data from CM7
     // Note: the ready bits not fully functional yet
     if(core_comms_channel_ready(comm_CM7_to_CM4_messages_ptr)) {      
       status = core_comms_channel_receive(comm_CM7_to_CM4_messages_ptr, (uint8_t *) from_cm7_buf, 48);
     }
+
+    // As CM4, Send message to CM7
+    while(!core_comms_channel_acknowledged(comm_CM4_to_CM7_messages_ptr));
+    status = core_comms_channel_send(comm_CM4_to_CM7_messages_ptr, (uint8_t *) to_cm7_buf, 48);
+
 
     // Record outgoing message
     // format_str(printbuffer, 100, "Sent: %s\n\0", to_cm7_buf);

--- a/AVI_FAS_FMC/CM7/Core/Src/main.c
+++ b/AVI_FAS_FMC/CM7/Core/Src/main.c
@@ -391,7 +391,7 @@ void CM7StatusLEDTask(void *argument)
     format_str(to_cm4_buf, 48, "To CM4: %s\0", from_cm4_buf);
 
     // As CM7, Send echoed message to CM4
-    // while(!core_comms_channel_acknowledged(comm_CM7_to_CM4_messages_ptr));
+    while(!core_comms_channel_acknowledged(comm_CM7_to_CM4_messages_ptr));
     status = core_comms_channel_send(comm_CM7_to_CM4_messages_ptr, (uint8_t *) to_cm4_buf, 48);
 
     /*

--- a/AVI_FAS_FMC/Custom/Shared/Include/core_comms.h
+++ b/AVI_FAS_FMC/Custom/Shared/Include/core_comms.h
@@ -10,7 +10,7 @@
 
 typedef struct core_comm_channel {
     volatile uint8_t buffer[CORE_COMM_CHANNEL_BUFFER_LEN];
-    osMutexId_t mutex_handle;
+    osSemaphoreId_t semaphore_handle;
     volatile int ready_to_read;
     volatile int receiver_acknowledged;
 } core_comm_channel;


### PR DESCRIPTION
Fixed potential deadlock regarding Inter-core communications. Here's the (potential) logic:

Loop 1: CM4 -> Sends message to CM7
Loop 2: CM4 has no message, so it goes directly to the "while not ack'd" loop. CM7 tries to read the ready_to_read state, but it does not get access to the mutex due to CM4's constant polling, so it skips. CM7 then sends CM4 a message.
Loop 3: CM7 _again_ tries to read the ready_to_read state, but it does not get access to the mutex due to CM4's constant polling, so it skips. Now CM7 loops, waiting for CM4 to ack its message, but it will never, thus a deadlock.

Solution: Use a semaphore instead of a mutex, so that it guarantees CM7 will be able to read CM4's message.

Draft PR for now, will have to wait until my replacement cables come in so I can test on the board. 




